### PR TITLE
Validate Login was using the wrong API method.

### DIFF
--- a/src/Whmcs.php
+++ b/src/Whmcs.php
@@ -118,7 +118,7 @@ class Whmcs
 	public function sbValidateLogin($email, $password2)
 	{
 		return (new Client)->post([
-			'action'    => 'getClientsDetails',
+			'action'    => 'ValidateLogin',
 			'email'     => $email,
 			'password2' => $password2,
 		]);


### PR DESCRIPTION
As result, all login validations were returning true regardless the password used to validate.