### PR TITLE
Added API access key support to bypass IP restrictions.

### DIFF
--- a/config/whmcs.php
+++ b/config/whmcs.php
@@ -42,6 +42,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | API Credentials
+    |--------------------------------------------------------------------------
+    |
+    | an access key can be configured to allow IP restrictions to be bypassed.
+
+    | It works by defining a secret key/passphrase in the WHMCS configuration.php
+    | file which is then passed into all API calls. To configure it, add a line 
+    | as follows to your configuration.php file in the root WHMCS directory.
+    |
+    | @see https://developers.whmcs.com/api/access-control/
+    |
+    */
+    'api_access_key'     => env('WHMCS_API_ACCESS_KEY', ''),
+
+    /*
+    |--------------------------------------------------------------------------
     | AutoAuth
     |--------------------------------------------------------------------------
     | Auth Key to automatically login the user to WHMCS if already loogged in

--- a/src/Client.php
+++ b/src/Client.php
@@ -18,7 +18,7 @@ class Client
      */
     public function __construct()
     {
-        $this->client = new GuzzleClient([
+        $options = [
             'timeout'     => 30,
             'debug'       => false,
             'http_errors' => true,
@@ -27,7 +27,11 @@ class Client
             'headers'     => [
                 'User-Agent' => 'sburina/laravel-whmcs-up',
             ],
-        ]);
+        ];
+
+        if(!empty(config('whmcs.api_access_key'))) $options['query'] = [ 'accesskey' => config('whmcs.api_access_key') ];
+
+        $this->client = new GuzzleClient($options);
     }
 
     /**


### PR DESCRIPTION
This is a small patch to easily bypass IP restrictions for whmcs API. Sometimes the IP exception does not work properly with local IP addresses, so this is very useful.
More info:- https://developers.whmcs.com/api/access-control/
Please feel free to edit if needed.

Thanks.